### PR TITLE
add hooks for modifying time before and after admin action

### DIFF
--- a/src/collections/Events.ts
+++ b/src/collections/Events.ts
@@ -1,4 +1,24 @@
-import { CollectionConfig } from 'payload/types';
+import { CollectionConfig, FieldHook } from 'payload/types';
+
+const addUTCOffset: FieldHook = async ({ 
+  value, 
+}) => {
+  const date: Date = new Date(value);
+  const offset = new Date().getTimezoneOffset() / 60;
+  date.setHours(date.getHours() + offset);
+
+  return date;
+};
+
+const removeUTCOffset: FieldHook = async ({ 
+  value, 
+}) => {
+  const date: Date = new Date(value);
+  const offset = new Date().getTimezoneOffset() / 60;
+  date.setHours(date.getHours() - offset);
+
+  return date;
+};
 
 const Events: CollectionConfig = {
   slug: 'events',
@@ -144,7 +164,15 @@ const Events: CollectionConfig = {
               pickerAppearance: 'timeOnly',
               timeFormat: 'HH:mm',
             }
-          }
+          },
+          hooks: {
+            beforeChange: [
+              removeUTCOffset,
+            ],
+            afterRead: [
+              addUTCOffset,
+            ]
+          },
         },
         {
           name: 'title',


### PR DESCRIPTION
Чтобы продолжать хранить время в UTC таймзоне в базе, но в админке при загрузке записи преобразовывать время в локальное для юзера, а перед сохранением изменений в БД снова преобразвывать обратно в UTC.